### PR TITLE
fix: package README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # rcsb-api-tools
 
-RCSB Saguaro Web API is an open-source library that includes different tools to validate and request data from the [1D Coordinate Server](https://1d-coordinates.rcsb.org), 
-the [RCSB Data API](https://data.rcsb.org) and the [RCSB Search Service](https://search.rcsb.org).
+RCSB Saguaro Web API is an open-source library that includes different tools to validate and request data from the [Sequence Coordinates Server](https://sequence-coordinates.rcsb.org/), the [RCSB Data API](https://data.rcsb.org) and the [RCSB Search Service](https://search.rcsb.org).
 
 ### Node Module Instalation
 `npm install @rcsb/rcsb-api-tools`
@@ -62,10 +61,10 @@ query QueryAlignment($queryId: String!, $from: String!, $to: String!, $range:[In
 #### data-api/yosemite server
 E.g. `import {CoreEntry, RcsbEntryContainerIdentifiers} from "@rcsb/rcsb-api-tools/build/RcsbGraphQL/Types/Yosemite/GqlTypes";`
 
-#### 1d-coordinates/borrego server
-E.g. `import {AnnotationFeatures, Feature, AlignmentResponse} from "@rcsb/rcsb-api-tools/build/RcsbGraphQL/Types/Borrego/GqlTypes";`
+#### sequence-coordinates/borrego server
+E.g. `import type {Query, SequenceAnnotations, SequenceAlignments} from '@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Types/Borrego/GqlTypes.js';`
 
-### GRphQL query validation
+### GraphQL query validation
 ````javascript
 import {validateQueries} from "@rcsb/rcsb-api-tools/build/RcsbGraphQL/Generator/GeneratorTools";
 validateQueries(graphql_schema_url, "path_to_queries/my_query.graphql");

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ query QueryAlignment($queryId: String!, $from: String!, $to: String!, $range:[In
 E.g. `import type {CoreEntry, RcsbEntryContainerIdentifiers} from "@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Types/Yosemite/GqlTypes";`
 
 #### sequence-coordinates/borrego server
-E.g. `import type {Query, SequenceAnnotations, SequenceAlignments} from '@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Types/Borrego/GqlTypes.js';`
+E.g. `import type {Query, SequenceAnnotations, SequenceAlignments} from '@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Types/Borrego/GqlTypes';`
 
 ### GraphQL query validation
 ````javascript

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ const query_params = {
 ##### query_string
 ```graphql
 query QueryAlignment($queryId: String!, $from: String!, $to: String!, $range:[Int!]){
-     alignment(
+     alignments(
          queryId:$queryId
          from:$from
          to:$to
          range:$range
      ){
          query_sequence
-         target_alignment {
+         target_alignments {
              target_id
              orientation
              target_sequence

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RCSB Saguaro Web API is an open-source library that includes different tools to 
 ### Requesting RCSB GraphQL data
 `import {GraphQLRequest} from "@rcsb/rcsb-api-tools/build/RcsbGraphQL/GraphQLRequest"`
 
-`const client = new GraphQLRequest("data-api"|"1d-coordinates"|url);`
+`const client = new GraphQLRequest("data-api"|"sequence-coordinates"|url);`
 
 `client.request(query_params, query_string)`;
 
@@ -59,29 +59,29 @@ query QueryAlignment($queryId: String!, $from: String!, $to: String!, $range:[In
 ### Importing RCSB GraphQL interfaces
 
 #### data-api/yosemite server
-E.g. `import {CoreEntry, RcsbEntryContainerIdentifiers} from "@rcsb/rcsb-api-tools/build/RcsbGraphQL/Types/Yosemite/GqlTypes";`
+E.g. `import type {CoreEntry, RcsbEntryContainerIdentifiers} from "@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Types/Yosemite/GqlTypes";`
 
 #### sequence-coordinates/borrego server
 E.g. `import type {Query, SequenceAnnotations, SequenceAlignments} from '@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Types/Borrego/GqlTypes.js';`
 
 ### GraphQL query validation
 ````javascript
-import {validateQueries} from "@rcsb/rcsb-api-tools/build/RcsbGraphQL/Generator/GeneratorTools";
+import {validateQueries} from "@rcsb/rcsb-api-tools/lib/RcsbGraphQL/Generator/GeneratorTools";
 validateQueries(graphql_schema_url, "path_to_queries/my_query.graphql");
 ````
 
 ### Requesting RCSB Search data
-`import {SearchRequest} from "@rcsb/rcsb-api-tools/build/RcsbSearch/SearchRequest";`
+`import {SearchRequest} from "@rcsb/rcsb-api-tools/lib/RcsbSearch/SearchRequest";`
 
 `const client = new SearchRequest();`
 
 `client.request(query_object);`
 
 #### Example
-```javascript
-import {SearchQuery} from "@rcsb/rcsb-api-tools/build/RcsbSearch/Types/SearchQueryInterface";
-import {LogicalOperator, ReturnType, Service, Type} from "@rcsb/rcsb-api-tools/build/RcsbSearch/Types/SearchEnums";
-import {RcsbSearchMetadata} from "@rcsb/rcsb-api-tools/build/RcsbSearch/Types/SearchMetadata";
+```typescript
+import type {SearchQuery} from "@rcsb/rcsb-api-tools/lib/RcsbSearch/Types/SearchQueryInterface";
+import {LogicalOperator, ReturnType, Service, Type} from "@rcsb/rcsb-api-tools/lib/RcsbSearch/Types/SearchEnums";
+import {RcsbSearchMetadata} from "@rcsb/rcsb-api-tools/lib/RcsbSearch/Types/SearchMetadata";
 
 const search_query = {
     query: {
@@ -116,7 +116,7 @@ search.request(search_query);
 #### Search metadata class
 Search metadata class provides the searchable paths and methods for the RCSB Search API 
 
-`import {RcsbSearchMetadata} from "@rcsb/rcsb-api-tools/build/RcsbSearch/Types/SearchMetadata";`
+`import {RcsbSearchMetadata} from "@rcsb/rcsb-api-tools/lib/RcsbSearch/Types/SearchMetadata";`
 
 ##### Utility examples
 E.g. `RcsbSearchMetadata.RcsbEntryInfo.DiffrnResolutionHigh.Value.path` attribute contains the string `"rcsb_entry_info.diffrn_resolution_high.value"`
@@ -126,7 +126,7 @@ E.g. `RcsbSearchMetadata.RcsbEntryInfo.DiffrnResolutionHigh.Value.operator` enum
 #### Search enums
 Search enums provide a collection of enums/classes that provide a controlled vocabulary to build the RCSB Search queries. 
 The name of each enum/class (camel cased) matches with the RCSB search schema field name in snake case format.
-E.g. `import {AggregationType, Operator, ReturnType, Service} from "@rcsb/rcsb-api-tools/build/RcsbSearch/Types/SearchEnums";`
+E.g. `import {AggregationType, Operator, ReturnType, Service} from "@rcsb/rcsb-api-tools/lib/RcsbSearch/Types/SearchEnums";`
 
 `AggregationType` encodes the possible values of the schema field `"aggregation_type"`, 
 i.e. `AggregationType.Terms = "terms"`, `AggregationType.Histogram = "histogram"`, ...
@@ -151,6 +151,6 @@ i.e. `AggregationType.Terms = "terms"`, `AggregationType.Histogram = "histogram"
   - E.g. `npm run downloadDwSchemas -- --schema-version 1.32.1-MODELS-SNAPSHOT`
   
 - Search schemas
-  -  `npm run downloadSearchSchemas --  --branch-name <GIT-REMOTE-BRANCH-NAME>`
-  -  E.g. `npm run downloadSearchSchemas --  --branch-name dev-computed-models`
+  - `npm run downloadSearchSchemas --  --branch-name <GIT-REMOTE-BRANCH-NAME>`
+  - E.g. `npm run downloadSearchSchemas --  --branch-name dev-computed-models`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rcsb/rcsb-api-tools",
-  "version": "5.0.0-dev-js-seqcoord.6",
+  "version": "5.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rcsb/rcsb-api-tools",
-      "version": "5.0.0-dev-js-seqcoord.6",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/cli": "^5.0.5",

--- a/src/RcsbGraphQL/GraphQLRequest.ts
+++ b/src/RcsbGraphQL/GraphQLRequest.ts
@@ -10,13 +10,12 @@ export class GraphQLRequest {
 
     private readonly client: GraphQLClient;
 
-    constructor(api: "data-api" | "1d-coordinates" | "sequence-coordinates" | string, config?: RequestConfig) {
+    constructor(api: "data-api" | "sequence-coordinates" | string, config?: RequestConfig) {
         switch (api){
             case "data-api":
                 this.client = new GraphQLClient(configYosemiteGraphQL.schema, config);
                 break;
             case "sequence-coordinates":
-            case "1d-coordinates":
                 this.client = new GraphQLClient(configBorregoGraphQL.schema, config);
                 break;
             default:


### PR DESCRIPTION
fixes #9 (at least the README desynchronisation with package's content)

- (Readme)Updated with correct links and endpoints renaming
- (Readme) Updated import and type import directives (`build` vs `lib`)
- (Readme) Updated query_string examples
- (Code) Removed "1d-coordinates" in `GraphQLRequest` constructor type signature
- updated `package-lock.json` content (`version` field)

**NB:** when running local npm scripts of the package (i.e. `npm run buildSearchInterface`), the file `src/RcsbSearch/Types/SearchMetadata.ts` has changed. **I didn't commited it yet**, awaiting some info from maintainers (ping @bioinsilico ?)

**STATUS**: 
- PR is ready, awaiting some feedback from maintainers (about whether `src/RcsbSearch/Types/SearchMetadata.ts` should be commited or not )
- It can be safely merged. ~~It could be safely merged when the last TODO will be done (coming soon).~~
- Another linked issue: #11 , but IMHO, should be addressed later.